### PR TITLE
changing tests to be pure

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,48 +1,45 @@
 var test = require('tape');
 var todoFunctions = require('./logic');
 
-tests for id to delete
+//tests for id to delete
 
-var arr = [
- {
-   id: 0,
-   description: 'smash avocados',
-   done: true,
- },
- {
-   id: 1,
-   description: 'make coffee',
-   done: false,
- },
+var arr = [{
+    id: 0,
+    description: 'smash avocados',
+    done: true,
+  },
+  {
+    id: 1,
+    description: 'make coffee',
+    done: false,
+  },
 ];
 
- test('should return an array', function(t){
-  var actual= Array.isArray(todoFunctions.deleteTodo([]));
+test('should return an array', function(t) {
+  var actual = Array.isArray(todoFunctions.deleteTodo([]));
   var expected = true;
   t.deepEqual(actual, expected, "deleteTodo function should return an array");
   t.end();
 });
 
-test('should not mutate original todo list', function(t){
-  var actual = [
-   {
-     id: 0,
-     description: 'smash avocados',
-     done: true
-   }];
-var expected = [
- {
-   id: 0,
-   description: 'smash avocados',
-   done: true
- }];
-todoFunctions.deleteTodo(actual);
+test('should not mutate original todo list', function(t) {
+  var actual = [{
+    id: 0,
+    description: 'smash avocados',
+    done: true
+  }];
+  var expected = [{
+    id: 0,
+    description: 'smash avocados',
+    done: true
+  }];
+  todoFunctions.deleteTodo(actual);
 
- t.deepEqual(actual, expected, "original list should not be mutated");
- t.end();
+  t.deepEqual(actual, expected, "original list should not be mutated");
+  t.end();
 });
 
-test('Should remove the object with the idtodelete value', function(t){
+test('Should remove the object with the idtodelete value', function(t) {
   var arr = [{
       id: 0,
       description: 'smash avocados',
@@ -55,69 +52,84 @@ test('Should remove the object with the idtodelete value', function(t){
     }
   ];
 
-var expected =   [{
+  var expected = [{
     id: 1,
     description: 'make coffee',
     done: false
   }];
 
- var actual = todoFunctions.deleteTodo(arr, 0);
- t.deepEqual(actual, expected, "delete todo reduces array length by one");
- t.end();
+  var actual = todoFunctions.deleteTodo(arr, 0);
+  t.deepEqual(actual, expected, "delete todo reduces array length by one");
+  t.end();
 });
 
 //addTodo Tests
-var todo = {
-            description: 'smash avocados',
-            done: true,
-            };
-var todoWithId = {
-            id: 0,
-            description: 'smash avocados',
-            done: true,
-            };
-
-var todoDoneFalse = {
-            id: 0,
-            description: 'smash avocados',
-            done: false,
-            };
 
 test('leave the input argument todos unchanged', function(t) {
+  var todo = {
+    description: 'smash avocados',
+    done: true,
+  };
   var actual = [];
   var expected = [];
-  todoFunctions.addTodo(actual, todo );
+  todoFunctions.addTodo(actual, todo);
   t.deepEqual(actual, expected, "array should not be mutated");
   t.end();
 });
 
 test('returns a new array with the new Todo added to the end', function(t) {
+  var todo = {
+    description: 'smash avocados',
+    done: true,
+  };
+
   var expected = [todo];
-  var actual = todoFunctions.addTodo([], todo );
+  var actual = todoFunctions.addTodo([], todo);
   t.deepEqual(actual, expected, "new todo object is added to array");
   t.end();
 });
 
 test('new to do object should be given an id', function(t) {
+  var todo = {
+    description: 'smash avocados',
+    done: true,
+  };
+
   var expected = true;
-  var actual = todoFunctions.addTodo([], todo )[0].hasOwnProperty('id');
+  var actual = todoFunctions.addTodo([], todo)[0].hasOwnProperty('id');
   t.equal(actual, expected, "object should have an id property");
   t.end();
 });
 
 //markTodo Tests
 test('should leave the input argument todos unchanged', function(t) {
+  var todoWithId = {
+    id: 0,
+    description: 'smash avocados',
+    done: true,
+  };
+
   var actual = [todoWithId];
   var expected = [todoWithId];
-  todoFunctions.markTodo(actual, 0 );
+  todoFunctions.markTodo(actual, 0);
   t.deepEqual(actual, expected, "input argument todos should be unchanged");
   t.end();
 });
 
 test('in the new todo array, all elements will remain unchanged except the one with id: idToMark', function(t) {
+  var todoWithId = {
+    id: 0,
+    description: 'smash avocados',
+    done: true,
+  };
+  var todoDoneFalse = {
+    id: 0,
+    description: 'smash avocados',
+    done: false,
+  };
   var expected = [todoWithId];
   var todoList = [todoDoneFalse];
-  var actual = todoFunctions.markTodo(todoList, 0 );
+  var actual = todoFunctions.markTodo(todoList, 0);
   t.deepEqual(actual, expected, "the done value of the object with the specified id should be toggled");
   t.end();
 });

--- a/test.js
+++ b/test.js
@@ -117,7 +117,7 @@ test('should leave the input argument todos unchanged', function(t) {
 });
 
 test('in the new todo array, all elements will remain unchanged except the one with id: idToMark', function(t) {
-  var todoWithId = {
+  var todoDoneTrue = {
     id: 0,
     description: 'smash avocados',
     done: true,
@@ -127,8 +127,13 @@ test('in the new todo array, all elements will remain unchanged except the one w
     description: 'smash avocados',
     done: false,
   };
-  var expected = [todoWithId];
-  var todoList = [todoDoneFalse];
+  var toDoOther = {
+    id: 1,
+    description: 'eating bananas',
+    done: false
+  };
+  var expected = [ todoDoneTrue, toDoOther ];
+  var todoList = [ todoDoneFalse, toDoOther ];
   var actual = todoFunctions.markTodo(todoList, 0);
   t.deepEqual(actual, expected, "the done value of the object with the specified id should be toggled");
   t.end();

--- a/test.js
+++ b/test.js
@@ -1,6 +1,8 @@
 var test = require('tape');
 var todoFunctions = require('./logic');
 
+tests for id to delete
+
 var arr = [
  {
    id: 0,
@@ -14,30 +16,53 @@ var arr = [
  },
 ];
 
- test('should return an object', function(t){
-  var actual= typeof todoFunctions.deleteTodo([]);
-  var expected = "object";
+ test('should return an array', function(t){
+  var actual= Array.isArray(todoFunctions.deleteTodo([]));
+  var expected = true;
   t.deepEqual(actual, expected, "deleteTodo function should return an array");
   t.end();
 });
 
-test('should return same list unchanged', function(t){
- var actual= todoFunctions.deleteTodo([]);
- var expected = [];
- t.deepEqual(actual, expected, "new list should remain unchanged");
+test('should not mutate original todo list', function(t){
+  var actual = [
+   {
+     id: 0,
+     description: 'smash avocados',
+     done: true
+   }];
+var expected = [
+ {
+   id: 0,
+   description: 'smash avocados',
+   done: true
+ }];
+todoFunctions.deleteTodo(actual);
+
+ t.deepEqual(actual, expected, "original list should not be mutated");
  t.end();
 });
 
-test('remove the object with the idtodelete value', function(t){
- var actual= todoFunctions.deleteTodo(arr, 0);
- var expected = [
-  {
+test('Should remove the object with the idtodelete value', function(t){
+  var arr = [{
+      id: 0,
+      description: 'smash avocados',
+      done: true
+    },
+    {
+      id: 1,
+      description: 'make coffee',
+      done: false
+    }
+  ];
+
+var expected =   [{
     id: 1,
     description: 'make coffee',
-    done: false,
-  },
- ];;
- t.deepEqual(actual, expected, "deleteTodo function should remove the object with idToDelete value");
+    done: false
+  }];
+
+ var actual = todoFunctions.deleteTodo(arr, 0);
+ t.deepEqual(actual, expected, "delete todo reduces array length by one");
  t.end();
 });
 
@@ -59,13 +84,14 @@ var todoDoneFalse = {
             };
 
 test('leave the input argument todos unchanged', function(t) {
+  var actual = [];
   var expected = [];
-  todoFunctions.addTodo(expected, todo );
-  t.deepEqual(expected, [], "array should not be mutated");
+  todoFunctions.addTodo(actual, todo );
+  t.deepEqual(actual, expected, "array should not be mutated");
   t.end();
 });
 
-test('returns a new array ith the new Todo added to the end', function(t) {
+test('returns a new array with the new Todo added to the end', function(t) {
   var expected = [todo];
   var actual = todoFunctions.addTodo([], todo );
   t.deepEqual(actual, expected, "new todo object is added to array");
@@ -81,16 +107,17 @@ test('new to do object should be given an id', function(t) {
 
 //markTodo Tests
 test('should leave the input argument todos unchanged', function(t) {
-  var expected = [];
-  todoFunctions.markTodo(expected, todo );
-  t.deepEqual(expected, [], "input argument todos should be unchanged");
+  var actual = [todoWithId];
+  var expected = [todoWithId];
+  todoFunctions.markTodo(actual, 0 );
+  t.deepEqual(actual, expected, "input argument todos should be unchanged");
   t.end();
 });
 
 test('in the new todo array, all elements will remain unchanged except the one with id: idToMark', function(t) {
-  var expected = [todoDoneFalse];
-  var todoList = [todoWithId];
+  var expected = [todoWithId];
+  var todoList = [todoDoneFalse];
   var actual = todoFunctions.markTodo(todoList, 0 );
-  t.deepEqual(expected, actual, "the done value of the object with the specified id should be toggled");
+  t.deepEqual(actual, expected, "the done value of the object with the specified id should be toggled");
   t.end();
 });


### PR DESCRIPTION
relates #16 

all tests refactoring with exception of final test in 'markTodo'
`test('in the new todo array, all elements will remain unchanged except the one with id: idToMark', function(t) {
  var expected = [todoWithId];
  var todoList = [todoDoneFalse];
  var actual = todoFunctions.markTodo(todoList, 0 );
  t.deepEqual(actual, expected, "the done value of the object with the specified id should be toggled");
  t.end();
});`